### PR TITLE
build: restoring packages before publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,19 @@ jobs:
       - image: circleci/node:10.15
     steps:
       - checkout
+
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+
+      - run:
+          name: restore-packages
+          command: npm ci
+
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+
       - run:
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc


### PR DESCRIPTION
The deploy is run as a separate workflow so needs to have all packages
restored.