### PR TITLE
docs: removing extra quote in github docs commit message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
             npm install -g --silent gh-pages
             git config user.email "ci-build@reactivemarkets.com"
             git config user.name "ci-build"
-            gh-pages --message "docs: updating from ${CIRCLE_SHA1}" [skip ci]" --dist docs
+            gh-pages --message "docs: updating from ${CIRCLE_SHA1} [skip ci]" --dist docs
 
 workflows:
   version: 2


### PR DESCRIPTION
Documentation generation failed due to an extra quote in the message.