### PR TITLE
build(circle-ci): adding sudo to install commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: coverage
           command: |
-            npm install -g --silent codecov
+            sudo npm install -g --silent codecov
             codecov -f packages/charts/coverage/*.json
 
   build-docs:
@@ -134,7 +134,7 @@ jobs:
       - run:
           name: Deploy documentation
           command: |
-            npm install -g --silent gh-pages
+            sudo npm install -g --silent gh-pages
             git config user.email "ci-build@reactivemarkets.com"
             git config user.name "ci-build"
             gh-pages --message "docs: updating from ${CIRCLE_SHA1} [skip ci]" --dist docs


### PR DESCRIPTION
Sudo is needed on Circle CI to install the codecov cli.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
