### PR TITLE
build(circle-ci): pages deploy doesn't work with sudo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - run:
           name: Deploy documentation
           command: |
-            sudo npm install -g --silent gh-pages
+            npm install -g --silent gh-pages
             git config user.email "ci-build@reactivemarkets.com"
             git config user.name "ci-build"
             gh-pages --message "docs: updating from ${CIRCLE_SHA1} [skip ci]" --dist docs


### PR DESCRIPTION
The pages deployment is using the standard node docker image so
doesn't require sudo.

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
