### PR TITLE
build(fossa): updating to just use the charts package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
       - run:
           name: fossa
           command: fossa
+          working_directory: packages/charts
 
   deploy:
     docker:


### PR DESCRIPTION
The license isn't being picked up I think because of the mono repo.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
