### PR TITLE
fix(charts): updating default time formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3076,6 +3076,7 @@
         "d3-time-format": "^2.2.2",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
+        "react-financial-charts": "file:packages/charts",
         "react-virtualized-auto-sizer": "^1.0.2"
       }
     },
@@ -14600,7 +14601,7 @@
         "d3-format": "^1.4.2",
         "d3-interpolate": "^1.4.0",
         "d3-path": "^1.0.9",
-        "d3-scale": "^3.2.0",
+        "d3-scale": "^3.2.1",
         "d3-selection": "^1.4.1",
         "d3-shape": "^1.3.7",
         "d3-time": "^1.1.0",

--- a/packages/charts/src/scale/levels.ts
+++ b/packages/charts/src/scale/levels.ts
@@ -1,17 +1,16 @@
 export const defaultFormatters = {
     yearFormat: "%Y",
-    quarterFormat: "%b %Y",
+    quarterFormat: "%b",
     monthFormat: "%b",
-    weekFormat: "%d %b",
-    dayFormat: "%a %d",
-    hourFormat: "%_I %p",
-    minuteFormat: "%I:%M %p",
-    secondFormat: "%I:%M:%S %p",
+    weekFormat: "%e",
+    dayFormat: "%e",
+    hourFormat: "%H:%M",
+    minuteFormat: "%H:%M",
+    secondFormat: "%H:%M:%S",
     milliSecondFormat: "%L",
 };
 
 export const levelDefinition = [
-    /* eslint-disable no-unused-vars */
     /* 19 */(d, date, i) => d.startOfYear && date.getFullYear() % 12 === 0 && "yearFormat",
     /* 18 */(d, date, i) => d.startOfYear && date.getFullYear() % 4 === 0 && "yearFormat",
     /* 17 */(d, date, i) => d.startOfYear && date.getFullYear() % 2 === 0 && "yearFormat",
@@ -32,5 +31,4 @@ export const levelDefinition = [
     /*  2 */(d, date, i) => d.startOfMinute && "minuteFormat",
     /*  1 */(d, date, i) => d.startOf30Seconds && "secondFormat",
     /*  0 */(d, date, i) => "secondFormat",
-    /* eslint-enable no-unused-vars */
 ];


### PR DESCRIPTION
Using 24 hour time.
Only showing month, removing year.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
