### PR TITLE
docs: correcting storybook config after version change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5162,6 +5162,7 @@
         "d3-time-format": "^2.2.3",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
+        "react-financial-charts": "file:packages/charts",
         "react-virtualized-auto-sizer": "^1.0.2"
       }
     },

--- a/packages/stories/.storybook/presets.js
+++ b/packages/stories/.storybook/presets.js
@@ -1,1 +1,1 @@
-module.exports = ['@storybook/addon-docs/react/preset'];
+module.exports = ['@storybook/addon-docs/preset'];


### PR DESCRIPTION
The docs don't render after a minor version upgrade. Updating the
presets to match a deprecation warning.

Resolves #236

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
