### PR TITLE
Update GenericComponent.tsx

### DIFF
--- a/packages/charts/src/GenericComponent.tsx
+++ b/packages/charts/src/GenericComponent.tsx
@@ -468,10 +468,11 @@ class GenericComponent extends React.Component<GenericComponentProps, GenericCom
         const moreProps = this.getMoreProps();
 
         const ctx = canvasToDraw(getCanvasContexts());
-
-        this.preCanvasDraw(ctx, moreProps);
-        canvasDraw(ctx, moreProps);
-        this.postCanvasDraw(ctx, moreProps);
+        if(ctx){
+            this.preCanvasDraw(ctx, moreProps);
+            canvasDraw(ctx, moreProps);
+            this.postCanvasDraw(ctx, moreProps);
+        }
     }
 
     public render() {
@@ -497,9 +498,13 @@ class GenericComponent extends React.Component<GenericComponentProps, GenericCom
 export default GenericComponent;
 
 export function getAxisCanvas(contexts) {
-    return contexts.axes;
+    if(contexts){
+        return contexts.axes;
+    }
 }
 
 export function getMouseCanvas(contexts) {
-    return contexts.mouseCoord;
+    if(contexts){
+        return contexts.mouseCoord;
+    }   
 }


### PR DESCRIPTION
Add undefined check before referring contexts object in getAxisCanvas/getMouseCanvas functions. Current code works(npm start) fine but will lead to error like "TypeError: Cannot read property 'mouseCoord' of undefined" in **jest snapshot generation process.** 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [Yes] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [Yes] documentation is updated
