### PR TITLE
fix: do not capture wheel when pan and zoom disabled

### DIFF
--- a/packages/core/src/EventCapture.tsx
+++ b/packages/core/src/EventCapture.tsx
@@ -198,7 +198,12 @@ export class EventCapture extends React.Component<EventCaptureProps, EventCaptur
     };
 
     public handleWheel = (e: React.WheelEvent) => {
-        const { onPan, zoom, onZoom } = this.props;
+        const { pan, onPan, zoom, onZoom } = this.props;
+
+        if (!pan && !zoom) {
+            return;
+        }
+
         const { panInProgress } = this.state;
 
         const yZoom = Math.abs(e.deltaY) > Math.abs(e.deltaX) && Math.abs(e.deltaY) > 0;


### PR DESCRIPTION
When pan and zoom is disabled, then users should be able to scroll past the chart without capturing the focus preventing scrolling.

See: https://github.com/reactivemarkets/react-financial-charts/issues/525

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
