### PR TITLE
Update CandlestickSeries.tsx

### DIFF
--- a/packages/series/src/CandlestickSeries.tsx
+++ b/packages/series/src/CandlestickSeries.tsx
@@ -132,8 +132,7 @@ export class CandlestickSeries extends React.Component<CandlestickSeriesProps> {
             plotData,
         });
 
-        const trueOffset = 0.5 * width;
-        const offset = trueOffset > 0.7 ? Math.round(trueOffset) : Math.floor(trueOffset);
+        const offset = 0.5 * width;
 
         return plotData
             .filter((d) => d.close !== undefined)


### PR DESCRIPTION
#### Current situation

The current code (lines 135-136) is discretizing `offset` (which is related to the candle's `width`) which isn't ideal and it's resulting in weird spacing issues when being zoomed out, due to the fact that it results in large discontinuous step/cliff changes.

#### Suggested change

There's a very simple one-line change that significantly improves the spacing behavior on the chart, by removing the discretization, which I've suggested here.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
