### PR TITLE
fix: do not round offset anymore

### DIFF
--- a/packages/series/src/CandlestickSeries.tsx
+++ b/packages/series/src/CandlestickSeries.tsx
@@ -132,8 +132,7 @@ export class CandlestickSeries extends React.Component<CandlestickSeriesProps> {
             plotData,
         });
 
-        const trueOffset = 0.5 * width;
-        const offset = trueOffset > 0.7 ? Math.round(trueOffset) : Math.floor(trueOffset);
+        const offset = 0.5 * width;
 
         return plotData
             .filter((d) => d.close !== undefined)


### PR DESCRIPTION
This change is to stop rounding the offset, in order to remove any large step changes at the boundaries whenever we're zoomed out (e.g. 1.0 suddenly changing to 2.0).

Please see the before and after results in the attached images. The before is from storybook on github. The after is from the my local machine.

![pre_change_ongithubwebsite](https://user-images.githubusercontent.com/1366642/125308865-4493b200-e2ff-11eb-86e6-4f78e2fd1633.png)

![post_change_onmymachine](https://user-images.githubusercontent.com/1366642/125308855-43628500-e2ff-11eb-9910-f85cae3f3123.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
