### PR TITLE
fix: stop rounding offset

### DIFF
--- a/packages/series/src/BarSeries.tsx
+++ b/packages/series/src/BarSeries.tsx
@@ -124,7 +124,7 @@ export class BarSeries extends React.Component<BarSeriesProps> {
             plotData,
         });
 
-        const offset = Math.floor(0.5 * barWidth);
+        const offset = 0.5 * barWidth;
 
         return plotData
             .map((d) => {


### PR DESCRIPTION
Stop rounding the offset so as to prevent step-change discontinuities. Improves the visual appearance of BarSeries when zooming out.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

Before (from github storybook)

![prechange_barseries_before](https://user-images.githubusercontent.com/1366642/125314874-97239d00-e304-11eb-88e1-1b7b2815f44b.png)

After (local machine)

![postchange_barseries](https://user-images.githubusercontent.com/1366642/125314895-9e4aab00-e304-11eb-845c-b21934f18586.png)


#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
