### PR TITLE
fix: remove rounding of x-axis location

### DIFF
--- a/packages/series/src/BarSeries.tsx
+++ b/packages/series/src/BarSeries.tsx
@@ -134,7 +134,7 @@ export class BarSeries extends React.Component<BarSeriesProps> {
                 }
 
                 const xValue = xAccessor(d);
-                const x = Math.round(xScale(xValue)) - offset;
+                const x = xScale(xValue) - offset;
 
                 let y = yScale(yValue);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

This will perfect the spacing between bars by removing the unnecessary discretization (which was impacting both `react-stockcharts` and `react-financial-charts`).

NOTE: This is #1 of 2 pull requests. This one is focused on BarSeries.tsx.

![postchange](https://user-images.githubusercontent.com/37128022/125335000-05268f00-e31a-11eb-8b0f-365a3d3ac336.png)


#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
