### PR TITLE
fix(series): fixing bug in CandlestickSeries

### DIFF
--- a/packages/series/src/CandlestickSeries.tsx
+++ b/packages/series/src/CandlestickSeries.tsx
@@ -135,7 +135,14 @@ export class CandlestickSeries extends React.Component<CandlestickSeriesProps> {
         const offset = 0.5 * width;
 
         return plotData
-            .filter((d) => d.close !== undefined)
+            .filter((d) => {
+                const ohlc = yAccessor(d);
+                if (ohlc === undefined) {
+                    return false;
+                }
+
+                return true;
+            })
             .map((d) => {
                 const ohlc = yAccessor(d);
                 if (ohlc === undefined) {


### PR DESCRIPTION
Filter was hardcoded to use the close instead of yAccessor.

Fixes #594

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
