### PR TITLE
fix: Add null check for utils.getMorePropsForChart

### DIFF
--- a/packages/interactive/src/utils.ts
+++ b/packages/interactive/src/utils.ts
@@ -84,6 +84,7 @@ export function getMorePropsForChart(moreProps: any, chartId: any) {
                 chartConfig,
                 mouseXY,
             };
+        }
     }
 }
 

--- a/packages/interactive/src/utils.ts
+++ b/packages/interactive/src/utils.ts
@@ -74,15 +74,17 @@ function getMouseXY(moreProps: any, [ox, oy]: any) {
 
 export function getMorePropsForChart(moreProps: any, chartId: any) {
     const { chartConfig: chartConfigList } = moreProps;
-    const chartConfig = chartConfigList.find((each: any) => each.id === chartId);
-
-    const { origin } = chartConfig;
-    const mouseXY = getMouseXY(moreProps, origin);
-    return {
-        ...moreProps,
-        chartConfig,
-        mouseXY,
-    };
+    if (chartConfigList && Array.isArray(chartConfigList)) {
+        const chartConfig = chartConfigList.find((each: any) => each.id === chartId);
+        if (chartConfig) {
+            const { origin } = chartConfig;
+            const mouseXY = getMouseXY(moreProps, origin);
+            return {
+                ...moreProps,
+                chartConfig,
+                mouseXY,
+            };
+    }
 }
 
 export function getSelected(interactives: any) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

When using the FibonacciRetracements component, I get an exception:

```
utils.ts:77 Uncaught TypeError: Cannot read properties of undefined (reading 'find')
    at getMorePropsForChart (utils.ts:77:1)
    at DrawingObjectSelector.tsx:39:1
    at index.ts:150:1
    at Array.forEach (<anonymous>)
    at mapObject (index.ts:148:1)
    at DrawingObjectSelector.getInteraction (DrawingObjectSelector.tsx:32:1)
    at DrawingObjectSelector.handleClick [as onMouseDown] (DrawingObjectSelector.tsx:67:1)
    at GenericComponent.evaluateType (GenericComponent.tsx:160:1)
    at GenericComponent.listener (GenericComponent.tsx:118:1)
    at ChartCanvas.tsx:911:1
```

In other places in the source code, I see that there is usually an [explicit check](https://github.com/react-financial/react-financial-charts/blob/745c7c04ec458a87663d2e50b3df815523bf24b5/packages/core/src/GenericChartComponent.tsx#L61) for the `chartConfig` property.  I have copied that here in utils.tsx

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
